### PR TITLE
new docker library images

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "jade": "~0.35.0",
     "jwt-simple": "^0.2.0",
     "mandrill-api": "^1.0.41",
-    "mongoose": "~3.8.0",
+    "mongoose": "^4.0.0",
     "mongoose-url-slugs": "0.0.10",
     "morgan": "^1.3.2",
     "node-sass-middleware": "^0.4.0",


### PR DESCRIPTION
readme updates for the new docker library images. "dockerfile/mongodb" => "library/mongo" and "dockerfile/redis" => "library/redis". in addition, bug fix with latest version of mongoose and the new libraries and added the database backup stuff from propatient to the readme.