### PR TITLE
correct syntax for absolute routes in ui-router.  makes it "localhost…

### DIFF
--- a/public/app/static/static-routes.js
+++ b/public/app/static/static-routes.js
@@ -28,12 +28,12 @@ angular.module('Yote')
     })
 
     .state('static.about', {
-      url: '/about'
+      url: '^/about'
       , templateUrl: '/html/static/templates/about'
     })
 
     .state('static.faq', {
-      url: '/faq'
+      url: '^/faq'
       , templateUrl: '/html/static/templates/faq'
     })
 


### PR DESCRIPTION
…:3030/about" instead of "localhost:3030//about"