### PR TITLE
Should fetch 2

### DIFF
--- a/client/modules/product/productActions.js
+++ b/client/modules/product/productActions.js
@@ -26,14 +26,14 @@ const shouldFetchSingle = (state, id) => {
     // the "selected" id changed, so we _should_ fetch
     // console.log("Y shouldFetch - true: id changed");
     return true;
-  } else if(!byId[id]) {
-    // the id is not in the map, fetch from server
-    // console.log("Y shouldFetch - true: not in map");
-    return true;
   } else if(selected.isFetching) {
     // "selected" is already fetching, don't do anything
     // console.log("Y shouldFetch - false: isFetching");
     return false;
+  } else if(!byId[id]) {
+    // the id is not in the map, fetch from server
+    // console.log("Y shouldFetch - true: not in map");
+    return true;
   } else if(new Date().getTime() - selected.lastUpdated > (1000 * 60 * 5)) {
     // it's been longer than 5 minutes since the last fetch, get a new one
     // console.log("Y shouldFetch - true: older than 5 minutes");
@@ -232,10 +232,6 @@ const shouldFetchList = (state, listArgs) => {
     // yes, the list we're looking for wasn't found
     // console.log("X shouldFetch - true: list not found");
     return true;
-  } else if(list.items.length < 1) {
-    // yes, the list we're looking for is empty
-    // console.log("X shouldFetch - true: length 0");
-    return true
   } else if(list.isFetching) {
     // no, this list is already fetching
     // console.log("X shouldFetch - false: fetching");

--- a/client/modules/user/userActions.js
+++ b/client/modules/user/userActions.js
@@ -219,14 +219,14 @@ const shouldFetchSingle = (state, id) => {
     // the "selected" id changed, so we _should_ fetch
     // console.log("shouldFetch - true: id changed");
     return true;
-  } else if(!byId[id]) {
-    // the id is not in the map, fetch from server
-    // console.log("shouldFetch - true: not in map");
-    return true;
   } else if(selected.isFetching) {
     // "selected" is already fetching, don't do anything
     // console.log("shouldFetch - false: isFetching");
     return false;
+  } else if(!byId[id]) {
+    // the id is not in the map, fetch from server
+    // console.log("shouldFetch - true: not in map");
+    return true;
   } else if(new Date().getTime() - selected.lastUpdated > (1000 * 60 * 5)) {
     // it's been longer than 5 minutes since the last fetch, get a new one
     // console.log("shouldFetch - true: older than 5 minutes");
@@ -425,10 +425,6 @@ const shouldFetchList = (state, listArgs) => {
     // yes, the list we're looking for wasn't found
     // console.log("shouldFetchList - true: list not found");
     return true;
-  } else if(list.items.length < 1) {
-    // yes, the list we're looking for is empty
-    // console.log("shouldFetchList - true: length 0");
-    return true
   } else if(list.isFetching) {
     // no, this list is already fetching
     // console.log("shouldFetchList - false: fetching");

--- a/server/logger.js
+++ b/server/logger.js
@@ -17,14 +17,15 @@ if(env == 'production') {
 
   //if prod, log to file and console
   var logger = new winston.Logger({
-    transports: [
-      new winston.transports.MongoDB({
-        level: 'info'
-        , db: config.db
-        , capped: true
-        , handleExceptions: true
-        , collection: 'logs'
-      })
+    // // these logs get massive on the database end and frankly we never use them.
+    // transports: [
+    //   new winston.transports.MongoDB({
+    //     level: 'info'
+    //     , db: config.db
+    //     , capped: true
+    //     , handleExceptions: true
+    //     , collection: 'logs'
+    //   })
       // NOTE: cannot get this to work on docker instance. it will not write to the linked docker volume for some reason. trying mongodb instead.
       // TODO: figure this out. logging to file would be more useful than to mongo
       // new winston.transports.File({


### PR DESCRIPTION
fix shouldFetch functionality. 2 changes:

for list, being length == 0 is valid and should not result in a new fetch. this can result in an infinite loop.
for single, check "isFetching" before checking if its in the map. can also result in an infinite loop.

also removed writing console logs to the prod database by default. this is filling up on some instances unreasonably fast.