### PR TITLE
prevent infinite in shouldFetch loops on server errors

### DIFF
--- a/client/modules/product/productActions.js
+++ b/client/modules/product/productActions.js
@@ -30,13 +30,17 @@ const shouldFetchSingle = (state, id) => {
     // "selected" is already fetching, don't do anything
     // console.log("Y shouldFetch - false: isFetching");
     return false;
-  } else if(!byId[id]) {
+  } else if(!byId[id] && !selected.error) {
     // the id is not in the map, fetch from server
+    // however, if the api returned an error, then it SHOULDN'T be in the map
+    // so re-fetching it will result in an infinite loop
     // console.log("Y shouldFetch - true: not in map");
     return true;
   } else if(new Date().getTime() - selected.lastUpdated > (1000 * 60 * 5)) {
     // it's been longer than 5 minutes since the last fetch, get a new one
     // console.log("Y shouldFetch - true: older than 5 minutes");
+    // also, don't automatically invalidate on server error. if server throws an error, 
+    // that won't change on subsequent requests and we will have an infinite loop
     return true;
   } else {
     // if "selected" is invalidated, fetch a new one, otherwise don't

--- a/client/modules/product/productReducers.js
+++ b/client/modules/product/productReducers.js
@@ -86,7 +86,6 @@ function productList(state = {
             items: [] // array of _id's
             , isFetching: false
             , error: action.error
-            , didInvalidate: true
             , lastUpdated: action.receivedAt
           })
         } else {
@@ -202,15 +201,12 @@ function product(state = {
           }
         })
       } else {
-        return Object.assign({}, state, {
-          selected: {
-            id: action.id
-            , isFetching: false
-            , error: action.error
-            , didInvalidate: true
-            , lastUpdated: action.receivedAt
-          }
+        let selected = Object.assign({}, state.selected, {
+          isFetching: false
+          , error: action.error
+          , lastUpdated: action.receivedAt
         })
+        return Object.assign({}, state, selected);
       }
     }
     case Actions.ADD_SINGLE_PRODUCT_TO_MAP: {

--- a/client/modules/user/userActions.js
+++ b/client/modules/user/userActions.js
@@ -223,7 +223,7 @@ const shouldFetchSingle = (state, id) => {
     // "selected" is already fetching, don't do anything
     // console.log("shouldFetch - false: isFetching");
     return false;
-  } else if(!byId[id]) {
+  } else if(!byId[id] && !selected.error) {
     // the id is not in the map, fetch from server
     // console.log("shouldFetch - true: not in map");
     return true;

--- a/client/modules/user/userReducers.js
+++ b/client/modules/user/userReducers.js
@@ -85,7 +85,6 @@ function userList(state = {
             items: [] // array of _id's
             , isFetching: false
             , error: action.error
-            , didInvalidate: true
             , lastUpdated: action.receivedAt
           })
         } else {
@@ -407,15 +406,12 @@ function user(state = {
           }
         })
       } else {
-        return Object.assign({}, state, {
-          selected: {
-            id: action.id
-            , isFetching: false
-            , error: action.error
-            , didInvalidate: true
-            , lastUpdated: action.receivedAt
-          }
+        let selected = Object.assign({}, state.selected, {
+          isFetching: false
+          , error: action.error
+          , lastUpdated: action.receivedAt
         })
+        return Object.assign({}, state, selected);
       }
     }
     case Actions.ADD_SINGLE_USER_TO_MAP: {


### PR DESCRIPTION
for both: don't invalidate on server fail responses. if the server returns false then calling it again from the front end won't change that and will result in infinite loops

for single: 
don't remove "id" on an error. this will ersult in infinite loops because changing it to null qualifies as a change, and will result in another request (and on and on)
if thing is not in the map, also check if it returned an error. a thing might not be in the map because it doesnt exist. so only query if also !error.
