### PR TITLE
fix getItem() in reducer

### DIFF
--- a/client/modules/product/productReducers.js
+++ b/client/modules/product/productReducers.js
@@ -395,7 +395,7 @@ function product(state = {
       if(!nextState.selected.id) {
         return null
       } else {
-        return nextState.byId[state.selected.id]
+        return nextState.byId[nextState.selected.id]
       }
     }
   })


### PR DESCRIPTION
interesting bug that only came up once we started fetching by something other than id. in getItem(), the item being requested was being retrieved by the _id in the previous state, not the new state. if fetching by id, though, this didn't result in any issues because the REQUEST_ method set the id. when fetching by something other than id, like slug, though, it doesnt get set until the RECEIVE_