### PR TITLE
master - use lodash deepCopy in create pages

### DIFF
--- a/client/modules/product/views/CreateProduct.js.jsx
+++ b/client/modules/product/views/CreateProduct.js.jsx
@@ -27,7 +27,7 @@ class CreateProduct extends Base {
   constructor(props) {
     super(props);
     this.state = {
-      product: { ...this.props.defaultProduct }
+      product: _.cloneDeep(this.props.defaultProduct)
 
       // NOTE: We don't want to actually change the store's defaultItem, just use a copy
     }

--- a/client/modules/user/views/AdminCreateUser.js.jsx
+++ b/client/modules/user/views/AdminCreateUser.js.jsx
@@ -26,7 +26,7 @@ class AdminCreateUser extends Base {
   constructor(props) {
     super(props);
     this.state = {
-      user: JSON.parse(JSON.stringify(props.defaultUser))
+      user: _.cloneDeep(props.defaultUser)
     }
     this._bind(
       '_handleFormChange'


### PR DESCRIPTION
we found this out a few weeks ago but haven't brought it in to yote yet. the spread operator copies all KEYS, but if the value is another object, it does not make a copy. for something like createDefaults, we need this to be a COPY of the existing object, so that the arrays/whatever are reinitialized. doesn't affect the product or user reducers specifically, but does affect other projects that have more complicated defaults.