### PR TITLE
3 - chained fetches

### DIFF
--- a/server/resources/product/productApi.js
+++ b/server/resources/product/productApi.js
@@ -5,10 +5,10 @@ const { requireLogin, requireAccountAccess } = require('../../global/handlers/au
 module.exports = (router) => {
 
   router.get('/api/products/default', product.getDefault)
-  router.get('/api/products/:id', requireLogin, product.getSingleById)
+  router.get('/api/products/:id', product.getSingleById)
 
 
-  router.get('/api/products', requireLogin, product.getListWithArgs)
+  router.get('/api/products', product.getListWithArgs)
 
   // // same but with api level restrictions
   // router.get('/api/products', 

--- a/web/src/global/utils/api.js
+++ b/web/src/global/utils/api.js
@@ -62,7 +62,7 @@ const apiUtils = {
     // ex: { page: '1', per: '20' } to ?page=1&per=20
     return Object.entries(queryObject)
       // remove empties
-      .filter(entry => entry[1].toString().length > 0)
+      .filter(entry => entry[1] && entry[1].toString().length > 0)
       // .filter(entry => entry[1] && entry[1].toString().length > 0)
       .map(item => {
         // debugging

--- a/web/src/global/utils/customHooks.js
+++ b/web/src/global/utils/customHooks.js
@@ -50,3 +50,29 @@ export const usePagination = (initialPagination = { page: 1, per: 10 }) => {
 
   return { ...pagination, setPage, setPer };
 }
+
+/**
+ * This hook checks for any undefined values in the listArgs object
+ * @param {object} listArgs - the object used to build the query string
+ * @returns {boolean} `true` if no listArg values equal `undefined`, otherwise `false`
+ */
+export const useCheckListArgsReady = (listArgs) => {
+  const [readyToFetch, setReadyToFetch] = useState(false);
+
+   useEffect(() => {
+    // make sure we aren't waiting for any listArgs
+    if(Object.keys(listArgs).length < 1) {
+      setReadyToFetch(false)
+    } else {
+      let allArgsArePresent = true;
+      Object.keys(listArgs).forEach(key => {
+        if(listArgs[key] === undefined) {
+          allArgsArePresent = false;
+        }
+        setReadyToFetch(allArgsArePresent)
+      });
+    }
+   }, [listArgs])
+  
+  return readyToFetch;
+}

--- a/web/src/global/utils/customHooks.js
+++ b/web/src/global/utils/customHooks.js
@@ -2,7 +2,7 @@
  * Custom hooks are stateful, reusable chunks of logic that we can use in functional components
  * Handy to cut down on repetitive boilerplate
  */
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 /**
  * This hook handles editing a resource object in component state before sending it to the server
@@ -59,7 +59,7 @@ export const usePagination = (initialPagination = { page: 1, per: 10 }) => {
 export const useCheckListArgsReady = (listArgs) => {
   const [readyToFetch, setReadyToFetch] = useState(false);
 
-   useEffect(() => {
+  useEffect(() => {
     // make sure we aren't waiting for any listArgs
     if(Object.keys(listArgs).length < 1) {
       setReadyToFetch(false)
@@ -69,10 +69,10 @@ export const useCheckListArgsReady = (listArgs) => {
         if(listArgs[key] === undefined) {
           allArgsArePresent = false;
         }
-        setReadyToFetch(allArgsArePresent)
       });
+      setReadyToFetch(allArgsArePresent);
     }
-   }, [listArgs])
-  
+  }, [listArgs])
+
   return readyToFetch;
 }

--- a/web/src/resources/product/productService.js
+++ b/web/src/resources/product/productService.js
@@ -303,7 +303,7 @@ export const useGetUpdatableProduct = (id) => {
 export const useDeleteProduct = () => {
   const dispatch = useDispatch();
   return {
-    // return the update action
+    // return the delete action
     sendDeleteProduct: (id) => dispatch(sendDeleteProduct(id))
   }
 }

--- a/web/src/resources/product/productStore.js
+++ b/web/src/resources/product/productStore.js
@@ -77,9 +77,6 @@ export const sendDeleteProduct = createAsyncThunk(
   }
 );
 
-// TODO: add sendDeleteProduct
-
-
 // next define the store's initial state
 const initialState = {
   /**
@@ -180,7 +177,7 @@ export const productStore = createSlice({
       .addCase(fetchDefaultProduct.fulfilled, (state, action) => {
         const defaultProduct = action.payload;
         // add it to the byId map (for the id we'll use 'defaultProduct')
-        state.byId['defaultProduct'] = defaultProduct
+        state.byId['defaultProduct'] = defaultProduct;
         // update the query object
         const singleQuery = state.singleQueries['defaultProduct'];
         singleQuery.status = 'fulfilled';
@@ -195,7 +192,7 @@ export const productStore = createSlice({
       })
       .addCase(fetchSingleProduct.pending, (state, action) => {
         // update or create a query object for it in the queries map
-        state.singleQueries[action.meta.arg] = { ...state.singleQueries[action.meta.arg], id: action.meta.arg, status: 'pending', didInvalidate: false };
+        state.singleQueries[action.meta.arg] = { ...state.singleQueries[action.meta.arg], id: action.meta.arg, status: 'pending', didInvalidate: false, error: null };
       })
       .addCase(fetchSingleProduct.fulfilled, (state, action) => {
         const product = action.payload;
@@ -216,7 +213,7 @@ export const productStore = createSlice({
       })
       .addCase(fetchProductList.pending, (state, action) => {
         // update or create the query object for it in the listQueries map
-        state.listQueries[action.meta.arg] = { ...state.listQueries[action.meta.arg], status: 'pending', didInvalidate: false };
+        state.listQueries[action.meta.arg] = { ...state.listQueries[action.meta.arg], status: 'pending', didInvalidate: false, error: null };
       })
       .addCase(fetchProductList.fulfilled, (state, action) => {
         const { products, totalPages } = action.payload;
@@ -261,7 +258,7 @@ export const productStore = createSlice({
         // get the product id
         const id = updatedProduct._id;
         // access or create the query object in the map
-        state.singleQueries[id] = { ...state.singleQueries[id], id: id, status: 'pending' }
+        state.singleQueries[id] = { ...state.singleQueries[id], id: id, status: 'pending', error: null }
 
         // optimistic update the version that's in the map
         state.byId[id] = { ...state.byId[id], ...updatedProduct}
@@ -278,12 +275,18 @@ export const productStore = createSlice({
       })
       .addCase(sendUpdateProduct.rejected, (state, action) => {
         // action.meta.arg in this case is the updated product object that was sent in the POST
-        const product = action.meta.arg
+        const product = action.meta.arg;
         // update the query object
         const singleQuery = state.singleQueries[product._id];
         singleQuery.status = 'rejected';
         singleQuery.error = action.error.message;
         singleQuery.receivedAt = Date.now();
+      })
+      .addCase(sendDeleteProduct.pending, (state, action) => {
+        // action.meta.arg in this case is the product id
+        const id = action.meta.arg;
+        // access or create the query object in the map
+        state.singleQueries[id] = { ...state.singleQueries[id], id: id, status: 'pending', error: null }
       })
       .addCase(sendDeleteProduct.fulfilled, (state, action) => {
         const productId = action.meta.arg;

--- a/web/src/resources/product/views/SingleProduct.jsx
+++ b/web/src/resources/product/views/SingleProduct.jsx
@@ -22,6 +22,12 @@ const SingleProduct = () => {
   // get the product from the store (or fetch it from the server)
   const { data: product, ...productQuery } = useGetProductById(productId);
 
+  // if you need information stored on `product` to perform other fetches use the examples below
+  // NOTE: if any listArg value (`category` in this case) is undefined then the hook will wait to perform the fetch
+  // const { data: relatedProducts, ...relatedProductsQuery } = useGetProductList({ category: product?.category })
+  // NOTE: if the id is undefined then the hook will wait to perform the fetch
+  // const { data: otherResource, ...otherResourceQuery } = useGetOtherResourceById(product?._otherResource);
+
   return (
     // <ProductLayout title={'Single Product'}>
     // { productQuery.isLoading ? <Skeleton />


### PR DESCRIPTION
PROBLEM: Sometimes you need a fetch to complete in order to dispatch some related fetch.
SOLUTION: Update the store service to check explicitly for `undefined` args and wait to fetch until all args are assigned a value.

NOTE: For list fetches, the mechanism assumes that we should only postpone the fetch while one or more of the args `=== undefined`. This means that we are allowed to fetch with args that are falsy (null, 0, "", etc...).

Also made sure to clear query errors when a new fetch is performed.