### PR TITLE
3 - form state and typos

### DIFF
--- a/server/resources/product/productController.js
+++ b/server/resources/product/productController.js
@@ -88,7 +88,7 @@ exports.getListWithArgs = async (req, res) => {
   // console.log("after parse", query, pagination, sort)
 
   // let query = {}
-  // let query = {type: "doesnt exist"}
+  // let query = {type: "doesn't exist"}
   // let query = "break me"
   // get count so we can determine total pages for front end to allow proper pagination
   const count = pagination ? await Product.countDocuments(query) : null

--- a/web/src/global/components/navigation/DefaultNav.jsx
+++ b/web/src/global/components/navigation/DefaultNav.jsx
@@ -33,8 +33,8 @@ const DefaultNav = () => {
   const location = useLocation();
 
   const handleLogout = async () => {
-    const { response } = await dispatch(sendLogout());
-    response && history.push("/");
+    const { payload } = await dispatch(sendLogout());
+    payload && history.push("/");
   }
 
   return (

--- a/web/src/global/utils/customHooks.js
+++ b/web/src/global/utils/customHooks.js
@@ -2,32 +2,7 @@
  * Custom hooks are stateful, reusable chunks of logic that we can use in functional components
  * Handy to cut down on repetitive boilerplate
  */
-import { useEffect, useState } from 'react'
-
-/**
- * This hook handles editing a resource object in component state before sending it to the server
- * @param {object} initialFormState - the object to be updated
- * @returns [ state, handleChange ]
- */
-export const useFormState = (initialFormState = {}) => {
-  // use the built-in `useState` hook to handle state
-  // useState can handle objects. More info: https://reactjs.org/docs/hooks-faq.html#should-i-use-one-or-many-state-variables
-  const [formState, setFormState] = useState(initialFormState);
-
-  // the `setFormState` method will replace the entire value in `formState`
-  // create a specific action to update nested state while preserving existing state(standard reducer pattern)
-  const handleFormChange = e => {
-    setFormState(state => ({ ...state, [e.target.name]: e.target.value }));
-  }
-
-  // mobile event handling is a little different 
-  // const handleFormChange = (e, target) => {
-  //   setFormState(state => ({ ...state, [target]: e.nativeEvent.text }));
-  // }
-
-  return [ formState, handleFormChange ];
-}
-
+import { useState } from 'react'
 
 /**
  * This hook handles pagination state

--- a/web/src/resources/notification/notificationService.js
+++ b/web/src/resources/notification/notificationService.js
@@ -261,17 +261,16 @@ export const useDeleteNotification = () => {
  * @returns an object containing fetch info and eventually the notification list (as `data`), also returns a function to dismiss a list of notifications
  * 
  */
-export const useStreamingNotificationList = ({ init } = {}) => {
+export const useStreamingNotificationList = ({ init }) => {
   const dispatch = useDispatch();
   // we'll need some way to reference the EventSource object. We'll use a ref to do that.
   const stream = useRef(null);
 
   // We are currently fetching by loggedInUser id. This should be enforced by the server, but we'll need some way to track the list in the store so we'll use this.
   const loggedInUser = useLoggedInUser();
-  const listArgs = { _user: loggedInUser._id };
 
   // first fetch the list using the standard hook
-  const { data: notificationList, ...notificationQuery } = useGetNotificationList(listArgs);
+  const { data: notificationList, ...notificationQuery } = useGetNotificationList({_user: loggedInUser._id});
   
   useEffect(() => {
     // when init is true (once at the top level component) we will start the stream
@@ -285,7 +284,7 @@ export const useStreamingNotificationList = ({ init } = {}) => {
         const notification = JSON.parse(event.data);
         if(notification && notification._id) {
           // this will add the notification to the store and update the notificationList being returned below
-          dispatch(addPushNotificationToStore({ notification, queryKey: apiUtils.queryStringFromObject(listArgs) }));
+          dispatch(addPushNotificationToStore({ notification, queryKey: apiUtils.queryStringFromObject({_user: loggedInUser._id}) }));
         }
       }
       stream.current.onerror = err => {
@@ -299,7 +298,7 @@ export const useStreamingNotificationList = ({ init } = {}) => {
       // stop the stream
       stream.current && stream.current.close();
     }
-  }, []);
+  }, [init, dispatch, loggedInUser._id]);
   
   // return the notificationList query as normal, it will be updated each time a new notification is received
   return {

--- a/web/src/resources/product/components/ProductForm.jsx
+++ b/web/src/resources/product/components/ProductForm.jsx
@@ -10,9 +10,6 @@ import PropTypes from 'prop-types';
 // import global components
 
 
-// hooks
-import { useFormState } from '../../../global/utils/customHooks';
-
 // import form components
 import { TextInput } from '../../../global/components/forms'
 
@@ -21,12 +18,10 @@ const ProductForm = ({
   , disabled
   , formTitle
   , formType
+  , handleFormChange
   , handleFormSubmit
   , product
 }) => {
-
-  // use the helper to handle product state
-  const [updatedProduct, handleChange] = useFormState(product); // pass product as initialState
 
   // set the button text
   const buttonText = formType === "create" ? "Create Product" : "Update Product";
@@ -34,28 +29,24 @@ const ProductForm = ({
   // set the form header
   const header = formTitle ? <div className="formHeader"><h2> {formTitle} </h2><hr /></div> : <div />;
   
-  const handleSubmit = e => {
-    e.preventDefault();
-    handleFormSubmit(updatedProduct)
-  }
 
   return (
     <div className="form-container">
-      <form name="productForm" className="product-form" onSubmit={handleSubmit}>
+      <form name="productForm" className="product-form" onSubmit={handleFormSubmit}>
         {header}
         <TextInput
           name="title"
           label="Title"
-          value={updatedProduct.title || ""}
-          change={handleChange}
+          value={product.title || ""}
+          change={handleFormChange}
           disabled={disabled}
           required={true}
         />
         <TextInput
           name="description"
           label="Description"
-          value={updatedProduct.description || ""}
-          change={handleChange}
+          value={product.description || ""}
+          change={handleFormChange}
           disabled={disabled}
           required={true}
         />
@@ -84,6 +75,7 @@ ProductForm.propTypes = {
   , disabled: PropTypes.bool
   , formTitle: PropTypes.string
   , formType: PropTypes.string.isRequired
+  , handleFormChange: PropTypes.func.isRequired
   , handleFormSubmit: PropTypes.func.isRequired
   , product: PropTypes.object.isRequired
 }

--- a/web/src/resources/product/views/UpdateProduct.jsx
+++ b/web/src/resources/product/views/UpdateProduct.jsx
@@ -1,5 +1,5 @@
 // import primary libraries
-import React from 'react'
+import React, {useEffect, useState} from 'react'
 // import PropTypes from 'prop-types'; // this component gets no props
 import { useParams, useHistory } from 'react-router-dom'
 
@@ -16,12 +16,26 @@ import { useGetUpdatableProduct } from '../productService';
 const UpdateProduct = () => {
   const history = useHistory(); // get history object
   const { productId } = useParams(); // replaces match.params.productId
-
+  const [updatedProduct, setUpdatedProduct] = useState({});
   // fetches and returns the product and the update action wrapped in dispatch.
   // another benefit of using this version is that productQuery.isFetching will be true while the update is being processed by the server.
   const { sendUpdateProduct, data: product, ...productQuery } = useGetUpdatableProduct(productId);
 
-  const handleFormSubmit = updatedProduct => {
+  // when the product is returned, set it to state
+  useEffect(() => {
+    if(product) {
+      setUpdatedProduct(product);
+    }
+  }, [product]);
+
+  // setProduct will replace the entire product object with the new product object
+  // set up a handleChange method to update nested state while preserving existing state (standard reducer pattern)
+  const handleFormChange = e => {
+    setUpdatedProduct({ ...updatedProduct, [e.target.name]: e.target.value });
+  }
+
+  const handleFormSubmit = e => {
+    e.preventDefault();
     // send the updatedProduct to the server
     sendUpdateProduct(updatedProduct);
     // back to single product view. We don't have to wait for the update to finish. It's okay if the product is still updating when the user gets to the single product view.
@@ -48,16 +62,14 @@ const UpdateProduct = () => {
     // <WaitOn/> handles all of the isLoading, isError, etc stuff so we don't have to do the stuff above
     <ProductLayout title={'Update Product'}>
       <WaitOn query={productQuery}>
-        { product &&
-          // we have the product, render the form
           <ProductForm
-            product={product}
+            product={updatedProduct}
             cancelLink={`/products/${productId}`}
             disabled={productQuery.isFetching}
             formType="update"
+            handleFormChange={handleFormChange}
             handleFormSubmit={handleFormSubmit}
           />
-        }
       </WaitOn>
     </ProductLayout>
   )

--- a/web/src/resources/user/authStore.js
+++ b/web/src/resources/user/authStore.js
@@ -75,8 +75,8 @@ export const authStore = createSlice({
         state.error = null
       })
       .addCase(sendLogin.fulfilled, (state, action) => {
-        state.loggedInUser = action.payload;
         state.status = 'idle';
+        state.loggedInUser = action.payload;
       })
       .addCase(sendLogin.rejected, (state, action) => {
         state.status = 'rejected';

--- a/web/src/resources/user/components/UserLoginForm.jsx
+++ b/web/src/resources/user/components/UserLoginForm.jsx
@@ -3,45 +3,35 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link, useLocation } from 'react-router-dom';
 
-// import hooks
-import { useFormState } from '../../../global/utils/customHooks';
-
 // import form components
 import { EmailInput, PasswordInput } from '../../../global/components/forms'
 
 const UserLoginForm = ({
-  handleFormSubmit
+  handleFormChange
+  , handleFormSubmit
   , user
 }) => {
   const location = useLocation();
 
-  const [updatedUser, handleChange] = useFormState(user); // pass user as initialState
-  
-  const handleSubmit = (e) => {
-    e.preventDefault();
-    handleFormSubmit(updatedUser)
-  }
 
   return (
     <div className="border border-solid bg-white shadow-sm rounded-sm mx-auto max-w-lg p-4 mt-16">
-      <form name="userForm" onSubmit={handleSubmit}>
+      <form name="userForm" onSubmit={handleFormSubmit}>
         <h1 className="px-2"> Sign In </h1>
         <EmailInput
           name="username"
           label="Email Address"
-          value={updatedUser.username}
-          change={handleChange}
+          value={user.username}
+          change={handleFormChange}
           required={true}
         />
         <PasswordInput
           name="password"
           label="Password"
-          value={updatedUser.password}
-          change={handleChange}
+          value={user.password}
+          change={handleFormChange}
           required={true}
         />
-
-
         <div className="p-2">
           <button className="text-sm p-2 px-8 rounded-full border border-solid bg-white text-gray-800 border border-gray-800 cursor-pointer no-underline font-semibold" type="submit" >Sign in</button>
         </div>
@@ -73,9 +63,9 @@ const UserLoginForm = ({
 }
 
 UserLoginForm.propTypes = {
-  handleFormSubmit: PropTypes.func.isRequired
+  handleFormChange: PropTypes.func.isRequired
+  , handleFormSubmit: PropTypes.func.isRequired
   , user: PropTypes.object.isRequired
-  , location: PropTypes.object
 }
 
 export default UserLoginForm;

--- a/web/src/resources/user/components/UserRegisterForm.jsx
+++ b/web/src/resources/user/components/UserRegisterForm.jsx
@@ -3,41 +3,33 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link, useLocation } from 'react-router-dom';
 
-// import hooks
-import { useFormState } from '../../../global/utils/customHooks';
-
 // import form components
 import { EmailInput, PasswordInput } from '../../../global/components/forms'
 
 const UserRegisterForm = ({
-  handleFormSubmit
+  handleFormChange
+  , handleFormSubmit
   , user
 }) => {
   const location = useLocation();
 
-  const [updatedUser, handleChange] = useFormState(user); // pass user as initialState
-  
-  const handleSubmit = (e) => {
-    e.preventDefault();
-    handleFormSubmit(updatedUser)
-  }
 
   return (
     <div className="border border-solid bg-white shadow-sm rounded-sm mx-auto max-w-lg p-4 mt-16">
-      <form name="userForm" onSubmit={handleSubmit}>
+      <form name="userForm" onSubmit={handleFormSubmit}>
         <h1 className="px-2">Register</h1>
         <EmailInput
           name="username"
           label="Email Address"
-          value={updatedUser.username}
-          change={handleChange}
+          value={user.username}
+          change={handleFormChange}
           required={true}
         />
         <PasswordInput
           name="password"
           label="Password"
-          value={updatedUser.password}
-          change={handleChange}
+          value={user.password}
+          change={handleFormChange}
           required={true}
         />
         <div className="p-2">
@@ -61,9 +53,9 @@ const UserRegisterForm = ({
 }
 
 UserRegisterForm.propTypes = {
-  handleFormSubmit: PropTypes.func.isRequired
+  handleFormChange: PropTypes.func.isRequired
+  , handleFormSubmit: PropTypes.func.isRequired
   , user: PropTypes.object.isRequired
-  , location: PropTypes.object
 }
 
 export default UserRegisterForm;

--- a/web/src/resources/user/views/UserLogin.jsx
+++ b/web/src/resources/user/views/UserLogin.jsx
@@ -8,7 +8,7 @@
  * /user/register without changing the original referring source route.
  */
 // import primary libraries
-import React from 'react';
+import React, { useState } from 'react';
 // import PropTypes from 'prop-types';
 
 import { useHistory, useLocation } from 'react-router-dom';
@@ -24,9 +24,11 @@ const UserLogin = () => {
   const dispatch = useDispatch();
   const history = useHistory();
   const location = useLocation();
+  const [user, setUser] = useState({username: '', password: ''});
 
-  const handleFormSubmit = async (userInfo) => {
-    const { payload: loggedInUser, error } = await dispatch(sendLogin(userInfo));
+  const handleFormSubmit = async (e) => {
+    e.preventDefault();
+    const { payload: loggedInUser, error } = await dispatch(sendLogin(user));
     // adapted from: https://reactrouter.com/web/example/auth-workflow
     const from = location.state.from || { pathname: "/" };
     if(loggedInUser) {
@@ -39,7 +41,8 @@ const UserLogin = () => {
   return  (
     <UserLayout title="Sign in">
       <UserLoginForm
-        user={{username: '', password: ''}}
+        user={user}
+        handleFormChange={e => setUser({...user, [e.target.name]: e.target.value})}
         handleFormSubmit={handleFormSubmit}
       />
     </UserLayout>

--- a/web/src/resources/user/views/UserRegister.jsx
+++ b/web/src/resources/user/views/UserRegister.jsx
@@ -8,7 +8,7 @@
  * /user/register without changing the original referring source route.
  */
 // import primary libraries
-import React from 'react';
+import React, { useState } from 'react';
 // import PropTypes from 'prop-types';
 
 import { useHistory, useLocation } from 'react-router-dom';
@@ -24,22 +24,25 @@ const UserRegister = () => {
   const dispatch = useDispatch();
   const history = useHistory();
   const location = useLocation();
+  const [user, setUser] = useState({username: '', password: ''});
 
-  const handleFormSubmit = async (userInfo) => {
-    const { payload: result } = await dispatch(sendRegister(userInfo));
+  const handleFormSubmit = async e => {
+    e.preventDefault();
+    const { payload: loggedInUser, error } = await dispatch(sendRegister(user));
     // adapted from: https://reactrouter.com/web/example/auth-workflow
     const from = location.state.from || { pathname: "/" };
-    if(result) {
-      history.replace(from);
+    if(loggedInUser) {
+      history.replace(from.pathname, location.state);
     } else {
-      alert("There was a problem registering")
+      alert(error.message || "There was a problem registering")
     }
   }
 
   return (
     <UserLayout title="Register">
       <UserRegisterForm
-        user={{username: '', password: ''}}
+        user={user}
+        handleFormChange={e => setUser({...user, [e.target.name]: e.target.value})}
         handleFormSubmit={handleFormSubmit}
       />
     </UserLayout>


### PR DESCRIPTION
- Remove the too clever `useFormState` hook.
- Move form state to the parent view for product and user. Now much more similar to previous yote.
