### PR TITLE
3 - url list query params

### DIFF
--- a/web/src/global/components/base/PaginatedList.jsx
+++ b/web/src/global/components/base/PaginatedList.jsx
@@ -5,20 +5,18 @@ import PropTypes from 'prop-types'
 import PageTabber from '../helpers/PageTabber'
 
 const PaginatedList = ({
-  children
+  as: Wrapper = 'ul' // the wrapper element for the list ('div', 'table', etc..), 'ul' by default
+  , children
   , className
-  , pagination: {
-    page
-    , per
-    , setPage
-    , setPer
-    , totalPages
-  }
+  , page
+  , per
+  , setPage
+  , totalPages
 }) => {
   // TODO: Add UI to use setPer
   const listRef = React.useRef(null);
   return (
-    <ul className={`p-2 ${className}`} ref={listRef}>
+    <Wrapper className={`${className}`} ref={listRef}>
       {children}
       {page && per && setPage ?
         <PageTabber
@@ -30,19 +28,16 @@ const PaginatedList = ({
         :
         null
       }
-    </ul>
+    </Wrapper>
   )
 }
 
 PaginatedList.propTypes = {
   className: PropTypes.string
-  , pagination: PropTypes.shape({
-    page: PropTypes.number
-    , per: PropTypes.number
-    , setPage: PropTypes.func
-    , setPer: PropTypes.func
-    , totalPages: PropTypes.number
-  })
+  , page: PropTypes.number
+  , per: PropTypes.number
+  , setPage: PropTypes.func
+  , totalPages: PropTypes.number
 }
 
 PaginatedList.defaultProps = {

--- a/web/src/global/components/helpers/PageTabber.jsx
+++ b/web/src/global/components/helpers/PageTabber.jsx
@@ -11,11 +11,11 @@ const PageTabber = ({
 }) => {
 
   const handleSetPage = (newPage) => {
-    setPage(newPage);
     onSetPage();
+    setPage(newPage);
   }
 
-
+  
   let before;
   let after;
   const currentPage = Number(pagination.page);
@@ -38,7 +38,7 @@ const PageTabber = ({
    * determine how many pages come after the current page and display (at most)
    * the next three
    */
-  if(!totalPages || currentPage === totalPages) {
+  if(!totalPages || currentPage >= totalPages) {
     after = [];
   } else if(currentPage === totalPages - 1) {
     after = [currentPage + 1];

--- a/web/src/global/utils/customHooks.js
+++ b/web/src/global/utils/customHooks.js
@@ -2,15 +2,16 @@
  * Custom hooks are stateful, reusable chunks of logic that we can use in functional components
  * Handy to cut down on repetitive boilerplate
  */
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo, useCallback } from 'react'
+import { useLocation, useHistory } from 'react-router-dom';
 
 /**
- * This hook handles pagination state
+ * This hook handles pagination state, for when we don't want to use url search params (e.g. for infinite scroll?)
  * @param {object} initialPagination - a pagination object, default is { page: 1, per: 10 }
  * @returns the pagination object and `setPage` and `setPer` functions
  */
-export const usePagination = (initialPagination = { page: 1, per: 10 }) => {
-  
+export const usePagination = (initialPagination = {}) => {
+
   // use the built-in `useState` hook to handle state
   const [pagination, setPagination] = useState(initialPagination);
 
@@ -20,7 +21,8 @@ export const usePagination = (initialPagination = { page: 1, per: 10 }) => {
   }
 
   const setPer = newPer => {
-    setPagination(state => ({ ...state, per: newPer || 10 }));
+    // reset the page to 1 when we change the per because the number of pages will change (and could be smaller than the current page)    
+    setPagination(state => ({ page: 1, per: newPer || 10 }));
   }
 
   return { ...pagination, setPage, setPer };
@@ -28,7 +30,7 @@ export const usePagination = (initialPagination = { page: 1, per: 10 }) => {
 
 /**
  * 
- * @returns {boolean} - true if the window is focused, false otherwise
+ * @returns {boolean} true if the window is focused, false otherwise
  */
 export const useIsFocused = () => {
   const [isFocused, setIsFocused] = useState(document.visibilityState === 'visible');
@@ -45,4 +47,48 @@ export const useIsFocused = () => {
   }, []);
 
   return isFocused;
+}
+
+/**
+ * 
+ * @param {object} defaultValues - an object of default values to assign to the url search params (if they aren't already there)
+ * @returns {[queryObject: queryObject, handleChange: Function]} an array with an object containing the search params as key/value pairs and a function to update the search params object
+ */
+export const useURLSearchParams = (defaultValues = {}) => {
+  const location = useLocation();
+  const history = useHistory();
+  const searchParams = useMemo(() => new URLSearchParams(location.search), [location.search]);
+
+  useEffect(() => {
+    // on mount, set default values
+    Object.keys(defaultValues).forEach(key => {
+      if (!searchParams.has(key)) {
+        searchParams.set(key, defaultValues[key].toString());
+      }
+    });
+    history.replace({ search: searchParams.toString() });
+  }, [searchParams]);
+
+  // return an object of key value pairs matching the search params to be used in list query
+  const queryObject = useMemo(() => {
+    const obj = {};
+    searchParams?.forEach((value, key) => {
+      obj[key] = value;
+    });
+    return obj;
+  }, [searchParams]);
+
+  const handleChange = useCallback((name, value) => {
+    // set the search param if needed
+    if (searchParams?.get(name) !== value) {
+      searchParams?.set(name, value);
+      // reset page to 1 when changing any other query param
+      if (searchParams?.has('page') && name !== 'page') {
+        searchParams?.set('page', '1');
+      }
+      history.push({ search: searchParams?.toString() });
+    }
+  }, [searchParams, history])
+
+  return [queryObject, handleChange];
 }

--- a/web/src/resources/product/views/ProductList.jsx
+++ b/web/src/resources/product/views/ProductList.jsx
@@ -14,8 +14,19 @@ import ProductLayout from '../components/ProductLayout.jsx';
 // import services
 import { useGetProductList } from '../productService';
 
+// import utils
+import { usePagination } from '../../../global/utils/customHooks';
+
 const ProductList = () => {
-  const { data: products, ids, pagination, ...productQuery } = useGetProductList({ page: 1, per: 5 });
+    // if we want to use internal state to track pagination we can use the old hook at the component level
+  const pageControls = usePagination({ page: 1, per: 1 });
+  const queryArgs = {
+    page: pageControls.page
+    , per: pageControls.per
+    // add other key:value pairs here to narrow the query
+    //, name: "some specific name"
+  }
+  const { data: products, ids, pagination, ...productQuery } = useGetProductList(queryArgs);
 
   return (
     <ProductLayout title={'Product List'}>
@@ -27,7 +38,8 @@ const ProductList = () => {
           </div>
         </header>
         <PaginatedList
-          pagination={pagination}
+          {...pagination}
+          {...pageControls} // must pass controls since this component is handling pagination on its own
           className={`${productQuery.isFetching ? 'opacity-50' : ''}`}
         >
           <WaitOn query={productQuery} fallback={<Skeleton count={pagination.per} />}>

--- a/web/src/resources/product/views/SearchableProductList.jsx
+++ b/web/src/resources/product/views/SearchableProductList.jsx
@@ -18,28 +18,12 @@ import ProductLayout from '../components/ProductLayout.jsx';
 
 // import services
 import { useGetProductList } from '../productService';
+import { useURLSearchParams } from '../../../global/utils/customHooks';
 
 const SearchableProductList = () => {
-  const initialPagination = { page: 1, per: 5 };
-  const [queryArgs, setQueryArgs] = useState({
-    // the server api will catch for this specific key `textSearch` and use it to search any indexed fields
-    textSearch: '' // search all by default
-  })
-
-  const { data: products, ids, pagination, ...productQuery } = useGetProductList({ ...queryArgs, ...initialPagination });
-
-  const handleQueryChange = useCallback((e) => {
-    const { name, value } = e.target;
-    // go back to page 1 when a new search term is entered
-    pagination.setPage(1);
-    // each time query args are changed, the api will be called with the new args
-    // we're debouncing the search input to avoid calling the api on every keystroke
-    setQueryArgs(args => ({
-      ...args
-      , [name]: value
-    }))
-    // React will complain that we don't have `pagination` in our dependencies, but that causes an infinite loop ¯\_(ツ)_/¯
-  }, [setQueryArgs])
+  // the server api will catch for this specific key `textSearch` and use it to search any indexed fields
+  const [productListArgs, handleChange] = useURLSearchParams({ page: 1, per: 25, sort: '-updated', textSearch: '' });
+  const { data: products, ids, pagination, ...productQuery } = useGetProductList(productListArgs);
 
   return (
     <ProductLayout title={'Search Product List'}>
@@ -50,19 +34,21 @@ const SearchableProductList = () => {
             <Link to="/products/new" className="text-sm p-2 px-8 rounded-full border-solid bg-white text-gray-800 border-gray-800 cursor-pointer no-underline font-semibold">New Product</Link>
           </div>
         </header>
-        <div className="max-w-xs">
-          <SearchInput
-            name="textSearch"
-            change={handleQueryChange}
-            placeholder="Search Products"
-            value={queryArgs.textSearch}
-            debounceTime={300}
-          />
-        </div>
         <PaginatedList
-          pagination={pagination}
-          className={`${productQuery.isFetching ? 'opacity-50' : ''}`}
+          as='div'
+          className={`scroll-mt-4 ${productQuery.isFetching ? 'opacity-50' : ''}`}
+          {...pagination}
+          setPage={(newPage) => handleChange('page', newPage)}
         >
+          <div className="max-w-xs">
+            <SearchInput
+              name="textSearch"
+              change={(e) => handleChange('textSearch', e.target.value)}
+              placeholder="Search Products"
+              value={productListArgs.textSearch}
+              debounceTime={300}
+            />
+          </div>
           <WaitOn query={productQuery} fallback={<Skeleton count={pagination.per} />}>
             {products?.map(product => <ProductListItem key={product._id} id={product._id} />)}
           </WaitOn>


### PR DESCRIPTION
NOTE: merge #259 first.

Save list args to url search params to enable browsing between list states. Completes [this todo](https://app.shortcut.com/pro-ficiency/story/2763/yote-update-list-queries-to-use-url-query-params) (no shortcut integration on this repo)

Also added an example of tracking pagination with internal state instead if needed.

